### PR TITLE
Chore: Enable Ubuntu 20.04 and 22.04 builder job

### DIFF
--- a/jjb/releng-packer-jobs.yaml
+++ b/jjb/releng-packer-jobs.yaml
@@ -28,6 +28,8 @@
       - centos-7
       - centos-cs-8
       - centos-cs-9
+      - ubuntu-20.04
+      - ubuntu-22.04
     templates: builder
     update-cloud-image: true
 


### PR DESCRIPTION
The Ubuntu builder jobs are required as a replacement for the ODL CentOS builder images.