### PR TITLE
Fix: Replace odl_system_image with Ubuntu 20.04

### DIFF
--- a/jjb/defaults.yaml
+++ b/jjb/defaults.yaml
@@ -101,7 +101,7 @@
     # CSIT configuration
     odl_system_count: 1
     odl_system_flavor: "v3-standard-4"
-    odl_system_image: "ZZCI - CentOS Stream 8 - builder - x86_64 - 20240601-160217.263"
+    odl_system_image: "ZZCI - Ubuntu 20.04 - builder - x86_64 - 20240820-011010.709"
     controller-max-mem: "2048m"
     openstack_system_count: 1
     openstack_system_flavor: "v3-standard-4"


### PR DESCRIPTION
A new Ubuntu 20.04 builder image has been built for the CSIT jobs as a replacement for CentOS 7/8 builders. CentOS 7/8 builders are soon going to be deprecated.