### PR TITLE
CI: Add Ubuntu 24.04 to platforms

### DIFF
--- a/jjb/releng-packer-jobs.yaml
+++ b/jjb/releng-packer-jobs.yaml
@@ -30,6 +30,8 @@
       - centos-cs-9
       - ubuntu-20.04
       - ubuntu-22.04
+      - ubuntu-24.04
+
     templates: builder
     update-cloud-image: true
 
@@ -174,6 +176,7 @@
       - ubuntu-18.04
       - ubuntu-20.04
       - ubuntu-22.04
+      - ubuntu-24.04
 
     templates: mininet-ovs-28
     update-cloud-image: true


### PR DESCRIPTION
Get CI builders ready for Ubuntu 20.04 LTS which has support until 2029.